### PR TITLE
Tests for rellineto and arc

### DIFF
--- a/shoebot/core/cairo_canvas.py
+++ b/shoebot/core/cairo_canvas.py
@@ -92,6 +92,12 @@ class CairoCanvas(Canvas):
 
         return moveto
 
+    def relmoveto_closure(self, x, y):
+        def relmoveto(ctx):
+            ctx.rel_move_to(x, y)
+
+        return relmoveto
+
     def lineto_closure(self, x, y):
         def lineto(ctx):
             ctx.line_to(x, y)
@@ -127,6 +133,12 @@ class CairoCanvas(Canvas):
                 ctx.restore()
 
         return ellipse
+
+    def relcurveto_closure(self, x1, y1, x2, y2, x3, y3):
+        def relcurveto(ctx):
+            ctx.rel_curve_to(x1, y1, x2, y2, x3, y3)
+
+        return relcurveto
 
     def rellineto_closure(self, x, y):
         def rellineto(ctx):

--- a/shoebot/data/bezier.py
+++ b/shoebot/data/bezier.py
@@ -148,8 +148,14 @@ class BezierPath(Grob, ColorMixin):
     def moveto(self, x, y):
         self._append_element(self._canvas.moveto_closure(x, y), (MOVETO, x, y))
 
+    def relmoveto(self, x, y):
+        self._append_element(self._canvas.relmoveto_closure(x, y), (RMOVETO, x, y))
+
     def lineto(self, x, y):
         self._append_element(self._canvas.lineto_closure(x, y), (LINETO, x, y))
+
+    def rellineto(self, x, y):
+        self._append_element(self._canvas.rellineto_closure(x, y), (RLINETO, x, y))
 
     def line(self, x1, y1, x2, y2):
         self.moveto(x1, y1)
@@ -159,6 +165,12 @@ class BezierPath(Grob, ColorMixin):
         self._append_element(
             self._canvas.curveto_closure(x1, y1, x2, y2, x3, y3),
             (CURVETO, x1, y1, x2, y2, x3, y3),
+        )
+
+    def relcurveto(self, x1, y1, x2, y2, x3, y3):
+        self._append_element(
+            self._canvas.relcurveto_closure(x1, y1, x2, y2, x3, y3),
+            (RCURVETO, x1, y1, x2, y2, x3, y3),
         )
 
     def arc(self, x, y, radius, angle1, angle2):
@@ -187,9 +199,6 @@ class BezierPath(Grob, ColorMixin):
             self._canvas.ellipse_closure(x, y, w, h), (ELLIPSE, x, y, w, h)
         )
         self.closed = True
-
-    def rellineto(self, x, y):
-        self._append_element(self._canvas.rellineto_closure(x, y), (RLINETO, x, y))
 
     def rect(self, x, y, w, h, roundness=0.0, rectmode=CORNER):
         # convert values if rectmode is not CORNER

--- a/tests/unittests/test_commands.py
+++ b/tests/unittests/test_commands.py
@@ -1,5 +1,6 @@
 import unittest
 
+from math import radians
 from parameterized import parameterized
 
 # Add stubs for all shoebot APIs called:
@@ -57,7 +58,7 @@ class TestPath(ShoebotTestCase):
             ),
             (
                 "arc(40, 40, 23, 90, 180)",
-                [PathElement(ARC, 40, 40, 23, 90, 180), PathElement(CLOSE, 40, 40)],
+                [PathElement(ARC, 40, 40, 23, radians(90), radians(180)), PathElement(CLOSE, 40, 40)],
             ),
         ]
     )

--- a/tests/unittests/test_commands.py
+++ b/tests/unittests/test_commands.py
@@ -2,9 +2,12 @@ import unittest
 
 from parameterized import parameterized
 
+# Add stubs for all shoebot APIs called:
 from tests.unittests.stubs.extras import flush_outputfile
 from tests.unittests.stubs.extras import outputfile
-from tests.unittests.stubs.nodebox import moveto, beginpath, endpath  # noqa
+from tests.unittests.stubs.nodebox import moveto  # noqa
+from tests.unittests.stubs.nodebox import beginpath  # noqa
+from tests.unittests.stubs.nodebox import endpath  # noqa
 from tests.unittests.stubs.nodebox import image  # noqa
 from tests.unittests.stubs.nodebox import size  # noqa
 from tests.unittests.stubs.nodebox import text  # noqa
@@ -34,6 +37,10 @@ class TestPath(ShoebotTestCase):
                 [PathElement(MOVETO, 40, 40), PathElement(CLOSE, 40, 40)],
             ),
             (
+                "relmoveto(40, 40)",
+                [PathElement(RMOVETO, 40, 40), PathElement(CLOSE, 40, 40)],
+            ),
+            (
                 "lineto(40, 40)",
                 [PathElement(LINETO, 40, 40), PathElement(CLOSE, 40, 40)],
             ),
@@ -48,13 +55,19 @@ class TestPath(ShoebotTestCase):
                     PathElement(CLOSE, 80, 80),
                 ],
             ),
+            (
+                "arc(40, 40, 23, 90, 180)",
+                [PathElement(ARC, 40, 40, 23, 90, 180), PathElement(CLOSE, 40, 40)],
+            ),
         ]
     )
     @test_as_bot()
     def test_path_commands(self, cmd, expected_elements):
         """
-        Run a command that should create path, first check if it requires beginpath
-        Then run with begin + endpath, and verify the path contains the expected elements.
+        Run a command that should create a one element path.
+
+        - Verify it requires beginpath.
+        - Run with begin + endpath, and verify the path contains the expected elements.
         """
         with self.assertRaises(ShoebotError):
             # ShoebotError should be raised if you haven't called beginpath

--- a/tests/unittests/test_commands.py
+++ b/tests/unittests/test_commands.py
@@ -6,6 +6,7 @@ from parameterized import parameterized
 # Add stubs for all shoebot APIs called:
 from tests.unittests.stubs.extras import flush_outputfile
 from tests.unittests.stubs.extras import outputfile
+from tests.unittests.stubs.nodebox import relmoveto  # noqa
 from tests.unittests.stubs.nodebox import moveto  # noqa
 from tests.unittests.stubs.nodebox import beginpath  # noqa
 from tests.unittests.stubs.nodebox import endpath  # noqa
@@ -19,6 +20,7 @@ from tests.unittests.helpers import test_as_bot
 from tests.unittests.helpers import TEST_INPUT_DIR
 
 from shoebot.data import CLOSE
+from shoebot.data import RCURVETO
 from shoebot.data import ShoebotError
 from shoebot.data import ARC
 from shoebot.data import CURVETO
@@ -42,6 +44,10 @@ class TestPath(ShoebotTestCase):
                 [PathElement(RMOVETO, 40, 40), PathElement(CLOSE, 40, 40)],
             ),
             (
+                "relmoveto(40, 40)",
+                [PathElement(RMOVETO, 40, 40), PathElement(CLOSE, 40, 40)],
+            ),
+            (
                 "lineto(40, 40)",
                 [PathElement(LINETO, 40, 40), PathElement(CLOSE, 40, 40)],
             ),
@@ -57,8 +63,18 @@ class TestPath(ShoebotTestCase):
                 ],
             ),
             (
+                "relcurveto(40, 40, 60, 60, 80, 80)",
+                [
+                    PathElement(RCURVETO, 40, 40, 60, 60, 80, 80),
+                    PathElement(CLOSE, 80, 80),
+                ],
+            ),
+            (
                 "arc(40, 40, 23, 90, 180)",
-                [PathElement(ARC, 40, 40, 23, radians(90), radians(180)), PathElement(CLOSE, 40, 40)],
+                [
+                    PathElement(ARC, 40, 40, 23, radians(90), radians(180)),
+                    PathElement(CLOSE, 40, 40),
+                ],
             ),
         ]
     )


### PR DESCRIPTION
Good news, our tests work - as is usually the case introducing tests to a codebase, some broken / inconsistent things were found.

@rlafuente hopefully you're OK to get ~~these couple of tests passing~~ this test to pass ?


Test:

https://github.com/shoebot/shoebot/blob/bug-path-api-fixes/tests/unittests/test_commands.py#L32

To run it:

Make sure you have the test requirements:
`$ pip install parameterized wrapt`

Go to the directory and run the tests:
```
$ cd tests/unittests
$ python -munittest test_commands.TestPath
```

This test makes bots like

`moveto(40, 40)`
^ and checks this raises and exception because there is no beginpath

```python
beginpath()
moveto(40, 40)
path = endpath()
```
^ and verifies `path` contains the expected PathElements (the lower le

Tests to make pass:
==
`relmoveto`
Fails because it tries to call a method in BezierPath that doesn't exist called `relmoveto`

~~`arc`#~~
~~- I wasn't really sure what PathElement this should create (though for everything else the parameters for PathElement are the same as the command)~~
~~- The CLOSE command should have the end coordinates, I wasn't sure what these should be, so the 40, 40 I put in will be wrong.~~
