### PR TITLE
Fix text.draw not working

### DIFF
--- a/shoebot/data/typography.py
+++ b/shoebot/data/typography.py
@@ -61,7 +61,7 @@ except ValueError as e:
             ULTRAHEAVY = 1000
 
         def __getattr__(self, item):
-            if item == 'Weight':
+            if item == "Weight":
                 return Weight
 
             raise NotImplementedError("FakePango does not implement %s" % item)
@@ -287,8 +287,7 @@ class Text(Grob, ColorMixin):
         return p
 
     def _get_center(self):
-        """Returns the center point of the path, disregarding transforms.
-        """
+        """Returns the center point of the path, disregarding transforms."""
         w, h = self._pango_layout.get_pixel_size()
         x = self.x + w / 2
         y = self.y + h / 2

--- a/shoebot/data/typography.py
+++ b/shoebot/data/typography.py
@@ -122,7 +122,7 @@ class Text(Grob, ColorMixin):
         height=None,
         outline=False,
         ctx=None,
-        enableRendering=True,
+        draw=True,
         **kwargs
     ):
         self._canvas = canvas = bot._canvas
@@ -153,15 +153,14 @@ class Text(Grob, ColorMixin):
         # Pre-render some stuff to enable metrics sizing
         self._pre_render()
 
-        if (
-            enableRendering
-        ):  # this way we do not render if we only need to create metrics
+        if draw:
+            # this way we do not render if we only need to create metrics
             if bool(ctx):
                 self._render(self._ctx)
             else:
                 # Normal rendering, can be deferred
                 self._deferred_render()
-        self._prerendered = enableRendering
+        self._prerendered = draw
 
     # pre rendering is needed to measure the metrics of the text, it's also useful to get the path, without the need to call _render()
     def _pre_render(self):

--- a/shoebot/grammar/drawbot.py
+++ b/shoebot/grammar/drawbot.py
@@ -321,9 +321,7 @@ class DrawBot(Bot):
         else:
             return txt
 
-    def textpath(
-        self, txt, x, y, width=None, height=1000000, enableRendering=False, **kwargs
-    ):
+    def textpath(self, txt, x, y, width=None, height=1000000, draw=False, **kwargs):
         """
         Draws an outlined path of the input text
         """
@@ -342,7 +340,7 @@ class DrawBot(Bot):
 
         # we send doRender=False to prevent the actual rendering process, only the path generation is enabled
         # not the most efficient way, but it generates accurate results
-        txt = self.Text(txt, 0, 0, width, height, enableRendering=False, **kwargs)
+        txt = self.Text(txt, 0, 0, width, height, draw=False, **kwargs)
         return txt.metrics
 
     def textwidth(self, txt, width=None):

--- a/shoebot/grammar/drawbot.py
+++ b/shoebot/grammar/drawbot.py
@@ -161,8 +161,7 @@ class DrawBot(Bot):
         self._path.rellineto(x, y)
 
     def relcurveto(self, h1x, h1y, h2x, h2y, x, y):
-        """Draws a curve relatively to the last point.
-        """
+        """Draws a curve relatively to the last point."""
         if self._path is None:
             raise ShoebotError(_("No current path. Use newpath() first."))
         self._path.relcurveto(x, y)
@@ -184,8 +183,7 @@ class DrawBot(Bot):
         draw=True,
         **kwargs
     ):
-        """Draws a image form path, in x,y and resize it to width, height dimensions.
-        """
+        """Draws a image form path, in x,y and resize it to width, height dimensions."""
         return self.Image(path, x, y, width, height, alpha, data, **kwargs)
 
     def imagesize(self, path):

--- a/shoebot/grammar/nodebox.py
+++ b/shoebot/grammar/nodebox.py
@@ -99,7 +99,7 @@ class NodeBot(Bot):
         alpha=1.0,
         data=None,
         draw=True,
-        **kwargs
+        **kwargs,
     ):
         """Draws a image form path, in x,y and resize it to width, height dimensions."""
         return self.Image(path, x, y, width, height, alpha, data, **kwargs)
@@ -636,7 +636,11 @@ class NodeBot(Bot):
             # do we have variants set?
             if not vars:
                 # make a list of "arg=value" strings to append to the font name below
-                variants = [f"{arg.replace('var_', '')}={value}" for arg, value in kwargs.items() if arg.startswith("var_")]
+                variants = [
+                    f"{arg.replace('var_', '')}={value}"
+                    for arg, value in kwargs.items()
+                    if arg.startswith("var_")
+                ]
             else:
                 # make a list of "arg=value" strings from the provided dict
                 variants = [f"{arg}={value}" for arg, value in vars.items()]

--- a/shoebot/grammar/nodebox.py
+++ b/shoebot/grammar/nodebox.py
@@ -698,7 +698,7 @@ class NodeBot(Bot):
         :param draw: Set to False to inhibit immediate drawing (defaults to False)
         :return: Path object representing the text.
         """
-        txt = self.Text(txt, x, y, width, height, enableRendering=False, **kwargs)
+        txt = self.Text(txt, x, y, width, height, draw=False, **kwargs)
         path = txt.path
         if draw:
             path.draw()
@@ -712,7 +712,7 @@ class NodeBot(Bot):
         """
         # for now only returns width and height (as per Nodebox behaviour)
         # but maybe we could use the other data from cairo
-        txt = self.Text(txt, 0, 0, width, height, enableRendering=False, **kwargs)
+        txt = self.Text(txt, 0, 0, width, height, draw=False, **kwargs)
         return txt.metrics
 
     def textwidth(self, txt, width=None):


### PR DESCRIPTION
Right now, setting the `draw` property to `False` in text() does nothing -- the text is rendered anyway.

This is because of an old parameter name (`enableRendering`), which was left there at some point (the old drawbot file shows it was called `doRender` earlier still) and should work like any other object's `draw` property.

This PR is a simple renaming of all instances i found of `enableRendering` to `draw`