### PR TITLE
Ensure sbot exits with errorcode 1 on script errors 

### DIFF
--- a/shoebot/__init__.py
+++ b/shoebot/__init__.py
@@ -370,8 +370,12 @@ def run(
             )
 
         sbot_thread = None
-        sbot = create_bot(*create_args, **create_kwargs)
-        sbot.run(*run_args, **run_kwargs)
+        try:
+            sbot = create_bot(*create_args, **create_kwargs)
+            sbot.run(*run_args, **run_kwargs)
+        except (ShoebotError, ShoebotScriptError):
+            if quit_on_error:
+                sys.exit(1)
 
     if run_shell:
         import shoebot.sbio.shell

--- a/shoebot/__init__.py
+++ b/shoebot/__init__.py
@@ -40,7 +40,7 @@ class ShoebotInstallError(Exception):
     pass
 
 
-from shoebot.data import ShoebotScriptError
+from shoebot.data import ShoebotError, ShoebotScriptError
 
 # TODO - Check if this needs importing here:
 # from shoebot.data import MOVETO, RMOVETO, LINETO, RLINETO, CURVETO, RCURVETO, ARC, ELLIPSE, CLOSE, LEFT, RIGHT, ShoebotError, ShoebotScriptError

--- a/shoebot/__init__.py
+++ b/shoebot/__init__.py
@@ -299,7 +299,7 @@ def run(
     See shoebot.io for implementation of the shell, and the gedit
     plugin for an example of using livecoding.
     """
-    # Munge shoebogt sys.argv
+    # Munge shoebot sys.argv
     sys.argv = [
         sys.argv[0]
     ] + args  # Remove shoebot parameters so sbot can be used in place of the python interpreter (e.g. for sphinx).

--- a/shoebot/data/__init__.py
+++ b/shoebot/data/__init__.py
@@ -65,5 +65,9 @@ class ShoebotError(Exception):
     pass
 
 
+class ShoebotScriptError(Exception):
+    pass
+
+
 class NodeBoxError(ShoebotError):
     pass

--- a/shoebot/grammar/grammar.py
+++ b/shoebot/grammar/grammar.py
@@ -210,7 +210,6 @@ class Grammar(object):
         run_forever=False,
         frame_limiter=False,
         verbose=False,
-        break_on_error=False,
     ):
         """
         Executes the contents of a Nodebox/Shoebot script
@@ -306,8 +305,6 @@ class Grammar(object):
                 errmsg = simple_traceback(e, executor.known_good or "")
             print(errmsg, file=sys.stderr)
             raise ShoebotScriptError()
-            if break_on_error:
-                raise
 
     def finish(self):
         ## For use when using shoebot as a module

--- a/shoebot/grammar/grammar.py
+++ b/shoebot/grammar/grammar.py
@@ -105,7 +105,7 @@ class Grammar(object):
     ### TODO - Move the logic of setup()/draw()
     ### to bot, but keep the other stuff here
     def _run_frame(self, executor, limit=False, iteration=0):
-        """ Run single frame of the bot
+        """Run single frame of the bot
 
         :param source_or_code: path to code to run, or actual code.
         :param limit: Time a frame should take to run (float - seconds)
@@ -316,7 +316,7 @@ class Grammar(object):
 
     #### Variables
     def _addvar(self, v):
-        """ Sets a new accessible variable.
+        """Sets a new accessible variable.
 
         :param v: Variable.
         """

--- a/shoebot/grammar/grammar.py
+++ b/shoebot/grammar/grammar.py
@@ -15,7 +15,7 @@ from shoebot.core.events import (
     SOURCE_CHANGED_EVENT,
 )
 from shoebot.core.var_listener import VarListener
-from shoebot.data import Variable
+from shoebot.data import Variable, ShoebotError, ShoebotScriptError
 from shoebot.grammar.format_traceback import simple_traceback
 from shoebot.util import UnbufferedFile
 
@@ -305,6 +305,7 @@ class Grammar(object):
             else:
                 errmsg = simple_traceback(e, executor.known_good or "")
             print(errmsg, file=sys.stderr)
+            raise ShoebotScriptError()
             if break_on_error:
                 raise
 

--- a/shoebot/run.py
+++ b/shoebot/run.py
@@ -289,6 +289,7 @@ def main():
         args=shlex.split(args.script_args or ""),
         verbose=args.verbose,
         background_thread=not args.disable_background_thread,
+        quit_on_error=True,
     )
 
 


### PR DESCRIPTION
This is needed for proper shell behavior, and also necessary for any external tool to get along with Shoebot. My workarounds while setting up error reporting on Atom got so messy that I decided to pick this up.

It's a bit brutish and I don't know how well this holds with other use cases besides simple script runs. Anyway here's a start, it works as expected now.