### PR TITLE
Fix socket server not starting

### DIFF
--- a/shoebot/sbio/socket_server.py
+++ b/shoebot/sbio/socket_server.py
@@ -82,7 +82,7 @@ class SocketServer(object):
     def listener(self, sock, *args):
         """Asynchronous connection listener. Starts a handler for each connection."""
         conn, addr = sock.accept()
-        f = conn.makefile(conn)
+        f = conn.makefile("rw")
         self.shell = ShoebotCmd(self.bot, stdin=f, stdout=f, intro=INTRO)
 
         print((_("Connected")))


### PR DESCRIPTION
It was using the wrong argument to makefile and throwing errors, probably because Py3 made things work differently. This slight update makes the socket server work again.