### PR TITLE
Improve run speed by trimming sleep() time in background thread

### DIFF
--- a/shoebot/__init__.py
+++ b/shoebot/__init__.py
@@ -378,7 +378,7 @@ def run(
     elif background_thread:
         try:
             while sbot_thread.is_alive():
-                sleep(0.05)
+                sleep(0.001)
         except KeyboardInterrupt:
             sbot_thread.send_sigint = False
             publish_event(QUIT_EVENT)

--- a/shoebot/__init__.py
+++ b/shoebot/__init__.py
@@ -378,7 +378,7 @@ def run(
     elif background_thread:
         try:
             while sbot_thread.is_alive():
-                sleep(1)
+                sleep(0.05)
         except KeyboardInterrupt:
             sbot_thread.send_sigint = False
             publish_event(QUIT_EVENT)


### PR DESCRIPTION
Maybe we can do without the call altogether? I don't know much about threading