### PR TITLE
Only import PIL Image when needed

### DIFF
--- a/shoebot/data/img.py
+++ b/shoebot/data/img.py
@@ -2,8 +2,6 @@ import array
 import os.path
 from io import StringIO
 
-from PIL import Image as PILImage
-
 from shoebot.core.backend import cairo, driver, gi
 from shoebot.util import _copy_attrs
 
@@ -100,6 +98,8 @@ class Image(Grob, ColorMixin):
                     sw = surface.get_width()
                     sh = surface.get_height()
                 else:
+                    from PIL import Image as PILImage
+
                     img = PILImage.open(path)
 
                     if img.mode != "RGBA":
@@ -115,6 +115,8 @@ class Image(Grob, ColorMixin):
 
                 self._surface_cache[path] = SurfaceRef(surface)
             else:
+                from PIL import Image as PILImage
+
                 img = PILImage.open(StringIO(self.data))
 
                 if img.mode != "RGBA":

--- a/shoebot/grammar/nodebox.py
+++ b/shoebot/grammar/nodebox.py
@@ -35,7 +35,6 @@ from shoebot.data import (
 
 from math import sin, cos, pi
 from math import radians as deg2rad
-from PIL import Image as PILImage
 
 import locale
 import gettext
@@ -136,9 +135,11 @@ class NodeBot(Bot):
 
     def imagesize(self, path):
         """
-        :param: path    Path to image file.
-        :return: image size as tuple (width, height)
+        :param path: Path to image file.
+        :return: image size as a (width, height) tuple
         """
+        from PIL import Image as PILImage
+
         img = PILImage.open(path)
         return img.size
 

--- a/shoebot/grammar/nodebox.py
+++ b/shoebot/grammar/nodebox.py
@@ -140,8 +140,8 @@ class NodeBot(Bot):
         """
         from PIL import Image as PILImage
 
-        img = PILImage.open(path)
-        return img.size
+        with PILImage.open(path) as img:
+            return img.size
 
     # Paths
 


### PR DESCRIPTION
Many use cases don't require image importing with image(), and even then PNG's are handled by Cairo, so PIL is only used with non-PNG images. 

This PR removes the initial PIL imports and places them only where they're needed. This way, Shoebot can be used without requiring PIL