### PR TITLE
Append numeric suffixes to snapshot filenames

### DIFF
--- a/shoebot/gui/gtk_window.py
+++ b/shoebot/gui/gtk_window.py
@@ -265,13 +265,20 @@ class ShoebotWindow(Gtk.Window, GtkInputDeviceMixin, DrawQueueSink):
 
     def output_image_filename(self, format):
         """
-        :param format:  Format, e.g. svg, pdf, png
+        :param format:  Format: "svg", "pdf", "png" or "ps"
         :return:  Full image filename, based on bot name
         """
         script = self.bot._namespace["__file__"]
-        frame = self.bot._namespace["ITERATION"]
+
         if script:
-            return f"{Path(script).stem}-{frame:04}.{format}"
+            filepath = Path(f"{Path(script).stem}.{format}")
+            if filepath.exists():
+                filecounter = 1
+                while filepath.exists():
+                    # try script-001, 002 and so on
+                    filepath = Path(f"{Path(script).stem}-{filecounter:03}.{format}")
+                    filecounter += 1
+            return str(filepath)
 
         return f"output.{format}"
 


### PR DESCRIPTION
Currently the snapshot filename is the script stem + format (script.svg), with a frame number suffix if it's animated (script-0139.svg)

However, when outputting from static bots, the filename is always the same so each snapshot is overwritten.

This PR does away with frame counts and uses ascending numeric suffixes so as not to overwrite existing files (script-001.png, script-002.png, etc.)

Not sure if you agree this is the way to go, but it was simple enough to just try it and discuss over working code :)

For some reason the "PNG windowed snapshot" unit test hangs (though windowed pdf passes), i'll track that one down later, but wanted to get this in.