### PR TITLE
Add label property to live vars

### DIFF
--- a/shoebot/grammar/bot.py
+++ b/shoebot/grammar/bot.py
@@ -293,9 +293,26 @@ class Bot(Grammar):
 
     # Variables #####
 
-    def var(self, name, type, default=None, min=0, max=255, value=None, step=None):
+    def var(
+        self,
+        name,
+        type,
+        default=None,
+        min=0,
+        max=255,
+        value=None,
+        step=None,
+        label=None,
+    ):
         v = Variable(
-            name, type, default=default, min=min, max=max, value=value, step=step,
+            name,
+            type,
+            default=default,
+            min=min,
+            max=max,
+            value=value,
+            step=step,
+            label=label,
         )
         return self._addvar(v)
 

--- a/shoebot/graphics/variable.py
+++ b/shoebot/graphics/variable.py
@@ -61,6 +61,7 @@ class Variable:
         self.value = kwargs.get("value", self.default)
         if self.value is None and self.default is not None:
             self.value = self.default
+        self.label = kwargs.get("label") or self.name.replace("_", " ").capitalize()
 
     def sanitize(self, val):
         """Given a Variable and a value, cleans it out."""

--- a/shoebot/gui/var_window.py
+++ b/shoebot/gui/var_window.py
@@ -17,11 +17,7 @@ BOOLEAN = 3
 BUTTON = 4
 
 
-def pretty_name(name):
-    return (name or "").replace("_", " ").capitalize()
-
-
-class VarWindow:
+class VarWindow(object):
     def __init__(self, parent, bot, title=None):
         self.parent = parent
         self.bot = bot
@@ -79,7 +75,7 @@ class VarWindow:
     def add_number(self, v):
         # create a slider for each var
         sliderbox = Gtk.HBox(homogeneous=False, spacing=0)
-        label = Gtk.Label(pretty_name(v.name))
+        label = Gtk.Label(v.label)
         sliderbox.pack_start(label, False, True, 20)
 
         if v.min != v.max:
@@ -102,7 +98,7 @@ class VarWindow:
 
     def add_text(self, v):
         textcontainer = Gtk.HBox(homogeneous=False, spacing=0)
-        label = Gtk.Label(pretty_name(v.name))
+        label = Gtk.Label(v.label)
         textcontainer.pack_start(label, False, True, 20)
 
         entry = Gtk.Entry()
@@ -115,7 +111,7 @@ class VarWindow:
 
     def add_boolean(self, v):
         buttoncontainer = Gtk.HBox(homogeneous=False, spacing=0)
-        button = Gtk.CheckButton(label=pretty_name(v.name))
+        button = Gtk.CheckButton(label=v.label)
         button.set_active(v.value)
         # we send the state of the button to the callback method
         button.connect("toggled", self.widget_changed, v)
@@ -135,7 +131,7 @@ class VarWindow:
             func = self.bot._namespace[func_name]
             func()
 
-        button = Gtk.Button(label=pretty_name(v.name))
+        button = Gtk.Button(label=v.label)
         button.connect("clicked", call_func, None)
         buttoncontainer.pack_start(button, True, True, 0)
         self.container.pack_start(buttoncontainer, True, True, 0)


### PR DESCRIPTION
This allows setting the visible label on the var windows with the new `label` keyword argument to `var()`.